### PR TITLE
Fix: Patch for hand draw bug

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -116,3 +116,10 @@ if next(find_joker("Lucky 7")) then
     end
 end
 '''
+
+[[patches]]
+[patches.regex]
+target = 'functions/state_events.lua'
+pattern = 'cards_to_draw\[i\]\.ability.extra_slots_used'
+position = 'at'
+payload = '(cards_to_draw[i] and cards_to_draw[i].ability and cards_to_draw[i].ability.extra_slots_used or 0)'


### PR DESCRIPTION
With only Extra Credit and Handy installed, game would often reach a state where the game would crash when trying to draw cards. After restarting and trying again, the same crash would happen.
This was the error message:
`INFO - [G] 2026-04-08 09:19:36 :: ERROR :: StackTrace :: Oops! The game crashed
functions/state_events.lua:352: attempt to index a nil value`
The log file for one of the incidents is attached.
[lovely-2026.04.08-08.36.22.log](https://github.com/user-attachments/files/26603167/lovely-2026.04.08-08.36.22.log)
I wrote a patch that adds a check that `cards_to_draw[i].ability` is not nil when `cards[i].ability.extra_slots_used` is accessed and it fixed the crash bug.